### PR TITLE
Fix NullableExtensions namespace & fix BoxedNullable

### DIFF
--- a/BoneLib/BoneLib/Nullables/BoxedNullable.cs
+++ b/BoneLib/BoneLib/Nullables/BoxedNullable.cs
@@ -19,7 +19,7 @@ namespace BoneLib.Nullables
             TClassPtr = Il2CppClassPointerStore<T>.NativeClassPtr;
 
             uint align = 0;
-            hasValueOffset = (int)IL2CPP.il2cpp_field_get_offset(IL2CPP.GetIl2CppField(classPtr, "has_value"));
+            hasValueOffset = (int)IL2CPP.il2cpp_field_get_offset(IL2CPP.GetIl2CppField(classPtr, "hasValue"));
             valueSize = IL2CPP.il2cpp_class_value_size(TClassPtr, ref align);
             marshalSize = Marshal.SizeOf(typeof(T));
         }

--- a/BoneLib/BoneLib/Nullables/NullableExtensions.cs
+++ b/BoneLib/BoneLib/Nullables/NullableExtensions.cs
@@ -11,7 +11,7 @@ using UnhollowerBaseLib;
 using UnityEngine;
 using UnityEngine.Audio;
 
-namespace ModThatIsNotMod.Nullables
+namespace BoneLib.Nullables
 {
     public static class NullableMethodExtensions
     {


### PR DESCRIPTION
1. When porting NullableExtensions, I didn't change the namespace.
2. Trev experienced crashing when using BoxedNullable was used. WNP decomp'd GameAssembly and found that mscorlib found has_value was changed to hasValue.