### PR TITLE
Major changes to player reference stuff

### DIFF
--- a/BoneLib/BoneLib/Hooking.cs
+++ b/BoneLib/BoneLib/Hooking.cs
@@ -34,6 +34,8 @@ namespace BoneLib
         public static event Action<bool> OnPlayerDeathImminent;
         public static event Action OnPlayerDeath;
 
+        public static event Action OnPlayerReferencesFound;
+
         internal static void SetHarmony(HarmonyLib.Harmony harmony) => Hooking.baseHarmony = harmony;
         internal static void InitHooks()
         {
@@ -49,9 +51,12 @@ namespace BoneLib
             CreateHook(typeof(Grip).GetMethod("OnAttachedToHand", AccessTools.all), typeof(Hooking).GetMethod(nameof(OnGripAttachedPostfix), AccessTools.all));
             CreateHook(typeof(Grip).GetMethod("OnDetachedFromHand", AccessTools.all), typeof(Hooking).GetMethod(nameof(OnGripDetachedPostfix), AccessTools.all));
 
+            CreateHook(typeof(RigManager).GetMethod("Awake", AccessTools.all), typeof(Hooking).GetMethod(nameof(OnRigManagerAwake), AccessTools.all));
+
             Player_Health.add_OnPlayerDamageReceived(OnPlayerDamageRecieved);
             Player_Health.add_OnDeathImminent(OnPlayerDeathImminent);
             Player_Health.add_OnPlayerDeath(OnPlayerDeath);
+
 
             while (delayedHooks.Count > 0)
             {
@@ -93,7 +98,11 @@ namespace BoneLib
 
         private static void OnGripAttachedPostfix(Grip __instance, Hand hand) => OnGripAttached?.Invoke(__instance, hand);
         private static void OnGripDetachedPostfix(Grip __instance, Hand hand) => OnGripDetached?.Invoke(__instance, hand);
-
+        private static void OnRigManagerAwake(RigManager __instance)
+        {
+            if (Player.FindObjectReferences(__instance))
+                OnPlayerReferencesFound?.Invoke();
+        }
         struct DelayedHookData
         {
             public MethodInfo original;

--- a/BoneLib/BoneLib/Main.cs
+++ b/BoneLib/BoneLib/Main.cs
@@ -27,9 +27,8 @@ namespace BoneLib
             ModConsole.Msg("BoneLib loaded");
         }
 
-        public override void OnSceneWasInitialized(int buildIndex, string sceneName)
+        public override void OnSceneWasLoaded(int buildIndex, string sceneName)
         {
-            Player.FindObjectReferences();
             PopupBoxManager.CreateBaseAd();
         }
 

--- a/BoneLib/BoneLib/Player.cs
+++ b/BoneLib/BoneLib/Player.cs
@@ -25,29 +25,27 @@ namespace BoneLib
 
         private static PhysicsRig physicsRig;
 
-        internal static void FindObjectReferences()
+        internal static bool FindObjectReferences(RigManager rigManager = null)
         {
             ModConsole.Msg("Finding player object references", LoggingMode.DEBUG);
 
-            Hand[] hands = GameObject.FindObjectsOfType<Hand>();
-            foreach (Hand hand in hands)
-            {
-                if (hand.name.ToLower().Contains("left"))
-                    leftHand = hand;
-                else if (hand.name.ToLower().Contains("right"))
-                    rightHand = hand;
-            }
-            BaseController[] baseControllers = GameObject.FindObjectsOfType<BaseController>();
-            foreach (BaseController baseController in baseControllers)
-            {
-                if (baseController.name.ToLower().Contains("left"))
-                    leftController = baseController;
-                else if (baseController.name.ToLower().Contains("right"))
-                    rightController = baseController;
-            }
-            controllerRig = GameObject.FindObjectOfType<ControllerRig>();
+            if (controllersExist && handsExist && controllerRig != null)
+                return false;
+            if (rigManager == null)
+                rigManager = GameObject.FindObjectOfType<RigManager>();
+
+            leftController = rigManager?.ControllerRig?.leftController;
+            rightController = rigManager?.ControllerRig?.rightController;
+
+            controllerRig = rigManager?.ControllerRig;
+
+            leftHand = rigManager?.physicsRig?.leftHand;
+            rightHand = rigManager?.physicsRig?.rightHand;
+            physicsRig = rigManager?.physicsRig;
 
             ModConsole.Msg("Found player object references", LoggingMode.DEBUG);
+
+            return controllersExist && handsExist && controllerRig != null;
         }
         /// <summary>
         /// Returns the root gameobject in the player rig manager.


### PR DESCRIPTION
- FindObjectReferences() now gets called when the rigmanager wakes up, which fixes the custom maps issue

- Added OnPlayerReferencesFound to Hooking.cs because OnSceneWasLoaded/Initialized doesn't work properly due to asset streaming (both get called multiple times in levels)

- Optimized OnPlayerReferencesFound()