### PR TITLE
Added support for updating an element while the menu is open

### DIFF
--- a/BoneLib/BoneLib/BoneMenu/Elements/GenericElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/GenericElement.cs
@@ -22,6 +22,12 @@ namespace BoneLib.BoneMenu.Elements
             return _value;
         }
 
+        public void SetValue(T value) 
+        {
+            _value = value;
+            OnUpdateVisuals.InvokeActionSafe();
+        }
+
         protected virtual void OnChangedValue()
         {
             SafeActions.InvokeActionSafe(_action, _value);

--- a/BoneLib/BoneLib/BoneMenu/Elements/MenuElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/Elements/MenuElement.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+﻿using System;
+
+using UnityEngine;
 
 namespace BoneLib.BoneMenu.Elements
 {
@@ -16,14 +18,18 @@ namespace BoneLib.BoneMenu.Elements
         public virtual ElementType Type => ElementType.Default;
         public virtual string DisplayValue => "Default";
 
+        internal Action OnUpdateVisuals;
+
         public void SetName(string name)
         {
             Name = name;
+            OnUpdateVisuals.InvokeActionSafe();
         }
 
         public void SetColor(Color color)
         {
             Color = color;
+            OnUpdateVisuals.InvokeActionSafe();
         }
 
         public virtual void OnSelectElement() { }

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/UIElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/UIElement.cs
@@ -21,7 +21,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(MenuElement element)
         {
             this.element = element;
-            element.OnUpdateVisuals += OnUpdateVisuals;
+            element.OnUpdateVisuals = OnUpdateVisuals;
 
             if (NameText != null)
             {

--- a/BoneLib/BoneLib/BoneMenu/UI/Elements/UIElement.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Elements/UIElement.cs
@@ -21,6 +21,7 @@ namespace BoneLib.BoneMenu.UI
         public void AssignElement(MenuElement element)
         {
             this.element = element;
+            element.OnUpdateVisuals += OnUpdateVisuals;
 
             if (NameText != null)
             {
@@ -59,6 +60,20 @@ namespace BoneLib.BoneMenu.UI
             }
 
             ValueText.text = value;
+        }
+
+        private void OnUpdateVisuals()
+        {
+            if (NameText != null)
+            {
+                NameText.text = element.Name;
+                NameText.color = element.Color;
+            }
+
+            if (ValueText != null)
+            {
+                ValueText.text = element.DisplayValue;
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, calling SetName and SetColor on a MenuElement would not update the text unless you close and re-open the menu. Additionally, there was no way to externally set the value of an element, such as with Reset buttons.
Now SetName and SetColor invoke OnUpdateVisuals, and SetValue is added to GenericElement. 
This has been tested and there seems to be no apparent issues, but this was made quickly.