### PR TITLE
Fix SkipIntro fog volume never fading out

### DIFF
--- a/BoneLib/BoneLib/Main.cs
+++ b/BoneLib/BoneLib/Main.cs
@@ -96,6 +96,7 @@ namespace BoneLib
                 controller.timerHold = 0;
                 controller.holdTime_Rest = 0;
                 controller.canClick = true;
+                controller.fadeVolume.gameObject.SetActive(false); // Set black fog volume to inactive to prevent it never fading out
             }
         }
     }


### PR DESCRIPTION
Apologies for accidentally closing other PR (edit: also just realised I should've reopened the closed one even though I deleted the repo -- sorry :/ )
Extremely simple fix for mild annoyance where if "Skip Intro" is true in MelonPreferences, the fog volume never gets disabled in 15 Void G114 (this change does not apply to 00 Main Menu)
### Old version
![Old version](https://i.imgur.com/eAHvQGs.jpg) 

### Fixed version
![Fixed version](https://i.imgur.com/ggHbEH6.jpg) 