### PR TITLE
SpawnCrate method in HelperMethods.cs

### DIFF
--- a/BoneLib/BoneLib/BoneLib.csproj
+++ b/BoneLib/BoneLib/BoneLib.csproj
@@ -88,7 +88,9 @@
     <Reference Include="UnhollowerRuntimeLib">
       <HintPath>..\..\References\MelonLoader\Managed\UnhollowerRuntimeLib.dll</HintPath>
     </Reference>
-    <Reference Include="UniTask, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="UniTask">
+      <HintPath>..\..\References\MelonLoader\Managed\UniTask.dll</HintPath>
+    </Reference>
     <Reference Include="Unity.ResourceManager">
       <HintPath>..\..\References\MelonLoader\Managed\Unity.ResourceManager.dll</HintPath>
     </Reference>

--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -1,5 +1,11 @@
-﻿using MelonLoader;
+﻿using System;
+using MelonLoader;
 using System.Text.RegularExpressions;
+using BoneLib.Nullables;
+using SLZ.Marrow.Data;
+using SLZ.Marrow.Pool;
+using SLZ.Marrow.Warehouse;
+using UnityEngine;
 
 namespace BoneLib
 {
@@ -22,5 +28,44 @@ namespace BoneLib
         public static bool IsAndroid() => isAndroid;
 
         private static readonly bool isAndroid = MelonUtils.CurrentPlatform == (MelonPlatformAttribute.CompatiblePlatforms)3;
+
+        /// <summary>
+        /// Spawns a crate from barcode.
+        /// </summary>
+        /// <param name="barcode">The barcode of the crate</param>
+        /// <param name="position">The position to spawn the crate at</param>
+        /// <param name="rotation">The rotation of the spawned object</param>
+        /// <param name="scale">The scale of the spawned object</param>
+        /// <param name="ignorePolicy">Ignore spawn policy or not</param>
+        /// <param name="spawnAction">Code to run once the spawnable is placed</param>
+        public static void SpawnCrate(string barcode, Vector3 position, Quaternion rotation, Vector3 scale, bool ignorePolicy, Action<GameObject> spawnAction)
+        {
+            var crateRef = new SpawnableCrateReference(barcode);
+            var spawnable = new Spawnable()
+            {
+                crateRef = crateRef,
+            };
+            AssetSpawner.Register(spawnable);
+            AssetSpawner.Spawn(spawnable, position, rotation, new BoxedNullable<Vector3>(scale), ignorePolicy,new BoxedNullable<int>(null), spawnAction);
+        }
+        
+        /// <summary>
+        /// Spawns a crate from a crate reference.
+        /// </summary>
+        /// <param name="crateReference">The crate reference to spawn</param>
+        /// <param name="position">The position to spawn the crate at</param>
+        /// <param name="rotation">The rotation of the spawned object</param>
+        /// <param name="scale">The scale of the spawned object</param>
+        /// <param name="ignorePolicy">Ignore spawn policy or not</param>
+        /// <param name="spawnAction">Code to run once the spawnable is placed</param>
+        public static void SpawnCrate(SpawnableCrateReference crateReference, Vector3 position, Quaternion rotation, Vector3 scale, bool ignorePolicy, Action<GameObject> spawnAction)
+        {
+            var spawnable = new Spawnable()
+            {
+                crateRef = crateReference,
+            };
+            AssetSpawner.Register(spawnable);
+            AssetSpawner.Spawn(spawnable, position, rotation, new BoxedNullable<Vector3>(scale), ignorePolicy,new BoxedNullable<int>(null), spawnAction);
+        }
     }
 }

--- a/BoneLib/BoneLib/Hooking.cs
+++ b/BoneLib/BoneLib/Hooking.cs
@@ -140,6 +140,7 @@ namespace BoneLib
                 // @Todo(Parzival): Some levels aren't done loading when RigManager.Awake is called!
                 // Ideally this should be invoked right before the loading screen dissapears, but this is
                 // the closest I can get it for now.
+                // You could use Player_Health.MakeVignette, that's almost always called when the RM is fully ready and the level's loaded.
                 SafeActions.InvokeActionSafe(OnLevelInitialized, new LevelInfo(SceneStreamer.Session.Level));
             }
         }


### PR DESCRIPTION
Would help keep code clean in mods that need to spawn a crate, instead of having to write out all the spawnable registering stuff you just give it a barcode or a cratereference.