### PR TITLE
Check If Assembly Loaded

### DIFF
--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -138,5 +138,13 @@ namespace BoneLib
             }
             return null;
         }
+        
+        ///<summary>
+        /// Checks if an assembly is loaded from name
+        /// </summary>
+        public static bool CheckIfAssemblyLoaded(string name)
+        {
+            return AppDomain.CurrentDomain.GetAssemblies().Any(asm => asm.GetName().Name.ToLower().Contains(name.ToLower()));
+        }
     }
 }


### PR DESCRIPTION
Give the method the name of the assembly as a string, returns true if it's loaded and false if it's not.
It converts the provided string and the assembly's name to lowercase before checking to prevent any casing problems.