### PR TITLE
Add OnWarehouseReady hook, make Some SpawnCrate Args Optional

### DIFF
--- a/BoneLib/BoneLib/CommonBarcodes.cs
+++ b/BoneLib/BoneLib/CommonBarcodes.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using SLZ.Marrow.SceneStreaming;
+// ReSharper disable MemberCanBePrivate.Global, it's a library, rider, these are supposed to be public.
 
 namespace BoneLib
 {

--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -42,7 +42,7 @@ namespace BoneLib
         /// <param name="scale">The scale of the spawned object</param>
         /// <param name="ignorePolicy">Ignore spawn policy or not</param>
         /// <param name="spawnAction">Code to run once the spawnable is placed</param>
-        public static void SpawnCrate(string barcode, Vector3 position, Quaternion rotation, Vector3 scale, bool ignorePolicy, Action<GameObject> spawnAction)
+        public static void SpawnCrate(string barcode, Vector3 position, Quaternion rotation = default, Vector3 scale = default, bool ignorePolicy = true, Action<GameObject> spawnAction = null)
         {
             var crateRef = new SpawnableCrateReference(barcode);
             var spawnable = new Spawnable()
@@ -62,7 +62,7 @@ namespace BoneLib
         /// <param name="scale">The scale of the spawned object</param>
         /// <param name="ignorePolicy">Ignore spawn policy or not</param>
         /// <param name="spawnAction">Code to run once the spawnable is placed</param>
-        public static void SpawnCrate(SpawnableCrateReference crateReference, Vector3 position, Quaternion rotation, Vector3 scale, bool ignorePolicy, Action<GameObject> spawnAction)
+        public static void SpawnCrate(SpawnableCrateReference crateReference, Vector3 position, Quaternion rotation = default, Vector3 scale = default, bool ignorePolicy = false, Action<GameObject> spawnAction = null)
         {
             var spawnable = new Spawnable()
             {

--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -42,7 +42,7 @@ namespace BoneLib
         /// <param name="scale">The scale of the spawned object</param>
         /// <param name="ignorePolicy">Ignore spawn policy or not</param>
         /// <param name="spawnAction">Code to run once the spawnable is placed</param>
-        public static void SpawnCrate(string barcode, Vector3 position, Quaternion rotation = default, Vector3 scale = default, bool ignorePolicy = true, Action<GameObject> spawnAction = null)
+        public static void SpawnCrate(string barcode, Vector3 position, Quaternion rotation = default, Vector3 scale = default, bool ignorePolicy = false, Action<GameObject> spawnAction = null)
         {
             var crateRef = new SpawnableCrateReference(barcode);
             var spawnable = new Spawnable()

--- a/BoneLib/BoneLib/Hooking.cs
+++ b/BoneLib/BoneLib/Hooking.cs
@@ -5,6 +5,7 @@ using SLZ.AI;
 using SLZ.Interaction;
 using SLZ.Marrow.SceneStreaming;
 using SLZ.Marrow.Utilities;
+using SLZ.Marrow.Warehouse;
 using SLZ.Props.Weapons;
 using SLZ.Rig;
 using SLZ.VRMK;
@@ -25,6 +26,7 @@ namespace BoneLib
 
         // Marrow
         public static event Action OnMarrowGameStarted;
+        public static event Action OnWarehouseReady;
 
         /// <summary>
         /// Called at the start of a loading screen.
@@ -66,9 +68,11 @@ namespace BoneLib
         private static bool currentLevelUnloaded = true;
 
         internal static void SetHarmony(HarmonyLib.Harmony harmony) => Hooking.baseHarmony = harmony;
+
         internal static void InitHooks()
         {
             MarrowGame.RegisterOnReadyAction(new Action(() => SafeActions.InvokeActionSafe(OnMarrowGameStarted)));
+            AssetWarehouse.OnReady(new Action(() => SafeActions.InvokeActionSafe(OnWarehouseReady)));
 
             CreateHook(typeof(RigManager).GetMethod("SwitchAvatar", AccessTools.all), typeof(Hooking).GetMethod(nameof(OnAvatarSwitchPrefix), AccessTools.all), true);
             CreateHook(typeof(RigManager).GetMethod("SwitchAvatar", AccessTools.all), typeof(Hooking).GetMethod(nameof(OnAvatarSwitchPostfix), AccessTools.all));


### PR DESCRIPTION
Rotation, scale, ignore policy, and spawnaction are now optional
```
Rotation defaults to (0, 0, 0, 1)
Scale defaults to (1, 1, 1)
IgnorePolicy defaults to false
SpawnAction defaults to null
```
You don't really _need_ to specify these, mainly just the crate/barcode and position, so they're now optional.