### PR TITLE
Embed PDB in DLL (for more descriptive errors)

### DIFF
--- a/BoneLib/BoneLib/BoneLib.csproj
+++ b/BoneLib/BoneLib/BoneLib.csproj
@@ -5,6 +5,12 @@
 	<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 	<GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>$(BONELAB_DIR)\MelonLoader\net6\0Harmony.dll</HintPath>


### PR DESCRIPTION
Makes VS embed the PDB into the DLL for both release and debug configurations.
I saw this option for Chaos which really fucking needed it and figured BoneLib might be able to get some use out of it.
The only downsides are as follows:
 - Probably slower exceptions (because the runtime would have to look up the line numbers)
 - Builder's directory structure (incl. user account name, if built under there, like in the default "repos" folder) being known (not a problem if using Actions to build, but idk if BoneLib does that)
 - Larger filesize (by probably not a lot)
 - ermmmm... too useful? idk.