### PR TITLE
Small Fixes & Changes

### DIFF
--- a/BoneLib/BoneLib/BoneMenu/Menu.cs
+++ b/BoneLib/BoneLib/BoneMenu/Menu.cs
@@ -8,8 +8,11 @@ namespace BoneLib.BoneMenu
     public static class Menu
     {
         public static event Action<Page> OnPageCreated;
+
         public static event Action<Page> OnPageOpened;
+
         public static event Action<Page> OnPageUpdated;
+
         public static event Action<Page> OnPageRemoved;
 
         public static Page CurrentPage
@@ -51,7 +54,7 @@ namespace BoneLib.BoneMenu
         /// <param name="page"></param>
         public static void DestroyPage(Page page)
         {
-            if (page.IsIndexedChild)
+            if (page.IsIndexedChild && CurrentPage == page)
             {
                 if (page.Parent.GetNextPage() != null)
                 {
@@ -101,7 +104,7 @@ namespace BoneLib.BoneMenu
             {
                 _currentPage = page;
             }
-            
+
             Internal_OnPageOpened(_currentPage);
         }
 
@@ -140,7 +143,7 @@ namespace BoneLib.BoneMenu
                 OpenPage(CurrentPage.NextPage());
             }
         }
-        
+
         public static void OpenParentPage()
         {
             if (CurrentPage.IsIndexedChild)
@@ -155,8 +158,8 @@ namespace BoneLib.BoneMenu
         }
 
         /// <summary>
-        /// Displays a dialog that can be used to inform the user. 
-        /// Useful for when a destructive action is about to be done, 
+        /// Displays a dialog that can be used to inform the user.
+        /// Useful for when a destructive action is about to be done,
         /// or can serve as an extra information window.
         /// </summary>
         /// <param name="title">The title of the dialog.</param>

--- a/BoneLib/BoneLib/BoneMenu/Page.cs
+++ b/BoneLib/BoneLib/BoneMenu/Page.cs
@@ -18,7 +18,7 @@ namespace BoneLib.BoneMenu
             _name = name;
             _color = Color.white;
             _maxElements = maxElements;
-            
+
             Background = null;
         }
 
@@ -81,7 +81,7 @@ namespace BoneLib.BoneMenu
             }
         }
 
-        public Color Color 
+        public Color Color
         {
             get
             {
@@ -225,7 +225,7 @@ namespace BoneLib.BoneMenu
             }
 
             _elements.Remove(element);
-            ModConsole.Msg("Remove Element");
+            ModConsole.Msg("Remove Element", LoggingMode.DEBUG);
             Menu.Internal_OnPageUpdated(this);
         }
 
@@ -320,7 +320,7 @@ namespace BoneLib.BoneMenu
 
             return _subPages[_subPageIndex];
         }
-        
+
         /// <summary>
         /// Goes to the previous indexed page.
         /// </summary>

--- a/BoneLib/BoneLib/BoneMenu/UI/Keyboard/Keyboard.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/Keyboard/Keyboard.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+
 using Il2CppTMPro;
+
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,7 +11,9 @@ namespace BoneLib.BoneMenu.UI
     [MelonLoader.RegisterTypeInIl2Cpp(false)]
     public sealed class Keyboard : MonoBehaviour
     {
-        public Keyboard(IntPtr ptr) : base(ptr) { }
+        public Keyboard(IntPtr ptr) : base(ptr)
+        {
+        }
 
         public TMP_InputField InputField => _inputField;
 
@@ -63,7 +67,6 @@ namespace BoneLib.BoneMenu.UI
 
             _connectedElement.Value = _inputField.text;
             _connectedElement.OnElementSelected();
-            _connectedGUIElement.Draw();
         }
     }
 }

--- a/BoneLib/BoneLib/RandomShit/PopupBoxManager.cs
+++ b/BoneLib/BoneLib/RandomShit/PopupBoxManager.cs
@@ -231,7 +231,7 @@ namespace BoneLib.RandomShit
             }
 
             string jsonUrls = urlReq.downloadHandler.text; // return value is something like ["https://cdn.shibe.online/shibes/8f0792fcac8df87a5d2953031a837a2939fda430.jpg"]
-            // Unfortunately the response is not ["link"] anymore, because the domain got sent into ww3 hell and of the other numbers. Both of the new endpoints use JSON and the "message" parameter to link to the message
+            // Unfortunately the response is not ["link"] anymore, because the domain got sent into ww3 hell and of the other numbers. Both of the new endpoints use JSON and the "message" parameter to link to the image
             string imageUrl = string.Empty;
             try
             {


### PR DESCRIPTION
Changes:
- When destroying a page and it is indexed, it will only redirect to the next/previous when you are viewing it. It used to change the page even if you weren't on that page
- Removed unnecessarily Draw method being called which under certain circumstances would make the string element be persistent on every page
- Changed logging mode of the "Remove Element" message to DEBUG to minimize lag when removing a lot of elements at once for normal players
- Fixed shibe, cat & bird ads not working