### PR TITLE
Simple audio functions

### DIFF
--- a/BoneLib/BoneLib/Audio.cs
+++ b/BoneLib/BoneLib/Audio.cs
@@ -21,6 +21,50 @@ namespace BoneLib
         public static AudioMixerGroup SoftInteraction => Audio3dManager.softInteraction;
         public static AudioMixerGroup UI => Audio3dManager.ui;
 
+        private static Audio3dManager _audioManager;
+
+        internal static void Initialize()
+        {
+            _audioManager = GameObject.FindObjectOfType<Audio3dManager>();
+        }
+
+        /// <summary>
+        /// Sets the LPF on the master mixer. Values close to 1 sound clear, while values
+        /// close to 0 sound more muffled.
+        /// </summary>
+        public static void SetMuffle(float muffle)
+        {
+            const float baseLPF = 22000;
+            _audioManager.SetLowPassFilter(muffle * baseLPF);
+        }
+
+        /// <summary>
+        /// Sets the master volume. This affects music, sfx, and other mixers.
+        /// </summary>
+        /// <param name="volume"></param>
+        public static void SetMasterVolume(int volume)
+        {
+            Audio3dManager.audio_Master = volume;
+        }
+
+        /// <summary>
+        /// Sets music volume.
+        /// </summary>
+        /// <param name="volume"></param>
+        public static void SetMusicVolume(int volume)
+        {
+            Audio3dManager.audio_Music = volume;
+        }
+
+        /// <summary>
+        /// Sets sound effect volume.
+        /// </summary>
+        /// <param name="volume"></param>
+        public static void SetSFXVolume(int volume)
+        {
+            Audio3dManager.audio_SFX = volume;
+        }
+
         /// <summary>
         /// Plays an audio clip with no spatial blend. Will be heard everywhere.
         /// </summary>

--- a/BoneLib/BoneLib/Main.cs
+++ b/BoneLib/BoneLib/Main.cs
@@ -3,6 +3,7 @@ using BoneLib.MonoBehaviours;
 using BoneLib.Notifications;
 using BoneLib.RandomShit;
 using Il2CppInterop.Runtime.Injection;
+using Il2CppSLZ.Marrow.Audio;
 using MelonLoader;
 
 namespace BoneLib
@@ -62,6 +63,7 @@ namespace BoneLib
         private void OnUIRigCreated()
         {
             MenuBootstrap.InitializeReferences();
+            Audio.Initialize();
         }
     }
 }


### PR DESCRIPTION
### Overview
This feature adds some simple functions for controlling game audio, and its low pass filter settings. It adds the following functions to the ``Audio`` class:
- ``SetMasterVolume``
- ``SetSFXVolume``
- ``SetMusicVolume``
- ``SetMuffle``

To be able to set muffling, an instance of an ``Audio3dManager`` object has to be found and used to even access the LPF. It's weird I know, as other functions in ``Audio3dManager`` are static.

### Example Usage
```cs
// Shellshock effect!
BoneLib.Audio.SetMasterVolume(3);
BoneLib.Audio.SetMuffle(0.25); // Values closer to zero sound more muffled
```