### PR TITLE
Add Infinite Ammo Toggle in Ammo Settings

### DIFF
--- a/BoneLib/BoneLib/BoneMenu/DefaultMenu.cs
+++ b/BoneLib/BoneLib/BoneMenu/DefaultMenu.cs
@@ -35,6 +35,11 @@ namespace BoneLib.BoneMenu
             Page itemSpawningPage = mainPage.CreatePage("Item Spawning", Color.white);
             Page funStuffPage = mainPage.CreatePage("Fun Stuff", Color.white);
 
+            ammoPage.CreateBool("Infinite Ammo", Color.white, Preferences.infiniteAmmo.entry.Value, (value) =>
+            {
+                Preferences.infiniteAmmo.entry.Value = value;
+                Preferences.Save();
+            });
             ammoPage.CreateFunction("Add Light Ammo", Color.white, () => AmmoInventory.AddCartridge(LightAmmo, lightAmmoValue));
             ammoPage.CreateFunction("Add Medium Ammo", Color.white, () => AmmoInventory.AddCartridge(MediumAmmo, mediumAmmoValue));
             ammoPage.CreateFunction("Add Heavy Ammo", Color.white, () => AmmoInventory.AddCartridge(HeavyAmmo, heavyAmmoValue));

--- a/BoneLib/BoneLib/Hooking.cs
+++ b/BoneLib/BoneLib/Hooking.cs
@@ -1,23 +1,21 @@
 ﻿using HarmonyLib;
-using MelonLoader;
-
+using Il2CppSLZ.Bonelab;
+using Il2CppSLZ.Marrow;
+using Il2CppSLZ.Marrow.AI;
+using Il2CppSLZ.Marrow.Data;
+using Il2CppSLZ.Marrow.PuppetMasta;
 using Il2CppSLZ.Marrow.SceneStreaming;
 using Il2CppSLZ.Marrow.Utilities;
 using Il2CppSLZ.Marrow.Warehouse;
 using Il2CppSLZ.VRMK;
-
+using MelonLoader;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-
 using UnityEngine;
-
-using Il2CppSLZ.Marrow.AI;
-using Il2CppSLZ.Marrow.PuppetMasta;
-using Il2CppSLZ.Marrow;
-using Il2CppSLZ.Bonelab;
+using static MelonLoader.MelonLogger;
 
 namespace BoneLib
 {
@@ -55,6 +53,8 @@ namespace BoneLib
         public static event Action<RigManager> OnPlayerDeathImminent;
         public static event Action<RigManager> OnPlayerDeath;
         public static event Action<RigManager> OnPlayerResurrected;
+        
+        public static event Action<CartridgeData, int> OnAmmoInventoryRemoveCartridge;
 
         // Interaction
         public static event Action<GameObject, Hand> OnGrabObject;
@@ -110,6 +110,8 @@ namespace BoneLib
             CreateHook(typeof(Player_Health).GetMethod(nameof(Player_Health.ApplyKillDamage), AccessTools.all), typeof(Hooking).GetMethod(nameof(OnPlayerDeathImminentPostfix), AccessTools.all));
             CreateHook(typeof(Player_Health).GetMethod(nameof(Player_Health.Death), AccessTools.all), typeof(Hooking).GetMethod(nameof(OnPlayerDeathPostfix), AccessTools.all));
             CreateHook(typeof(Player_Health).GetMethod(nameof(Player_Health.LifeSavingDamgeDealt), AccessTools.all), typeof(Hooking).GetMethod(nameof(OnPlayerResurrectedPostfix), AccessTools.all));
+
+            CreateHook(typeof(AmmoInventory).GetMethod(nameof(AmmoInventory.RemoveCartridge), AccessTools.all), typeof(Hooking).GetMethod(nameof(OnAmmoInventoryRemoveCartridgePostfix), AccessTools.all));
 
             while (delayedHooks.Count > 0)
             {
@@ -219,6 +221,8 @@ namespace BoneLib
         private static void OnPlayerDeathPostfix(Player_Health __instance) => SafeActions.InvokeActionSafe(OnPlayerDeath, __instance._rigManager);
         private static void OnPlayerDeathImminentPostfix(Player_Health __instance) => SafeActions.InvokeActionSafe(OnPlayerDeathImminent, __instance._rigManager);
         private static void OnPlayerResurrectedPostfix(Player_Health __instance) => SafeActions.InvokeActionSafe(OnPlayerResurrected, __instance._rigManager);
+
+        private static void OnAmmoInventoryRemoveCartridgePostfix(AmmoInventory __instance, CartridgeData cartridge, int count) => SafeActions.InvokeActionSafe(OnAmmoInventoryRemoveCartridge, cartridge, count);
 
         private struct DelayedHookData
         {

--- a/BoneLib/BoneLib/Main.cs
+++ b/BoneLib/BoneLib/Main.cs
@@ -3,6 +3,7 @@ using BoneLib.MonoBehaviours;
 using BoneLib.Notifications;
 using BoneLib.RandomShit;
 using Il2CppInterop.Runtime.Injection;
+using Il2CppSLZ.Marrow;
 using Il2CppSLZ.Marrow.Audio;
 using MelonLoader;
 
@@ -37,6 +38,7 @@ namespace BoneLib
 
             Hooking.OnLevelLoaded += OnLevelLoaded;
             Hooking.OnUIRigCreated += OnUIRigCreated;
+            Hooking.OnAmmoInventoryRemoveCartridge += OnAmmoInventoryRemoveCartridge;
 
             ClassInjector.RegisterTypeInIl2Cpp<PopupBox>();
 
@@ -64,6 +66,14 @@ namespace BoneLib
         {
             MenuBootstrap.InitializeReferences();
             Audio.Initialize();
+        }
+
+        private void OnAmmoInventoryRemoveCartridge(Il2CppSLZ.Marrow.Data.CartridgeData cartridge, int count)
+        {
+            if (Preferences.infiniteAmmo.entry.Value)
+            {
+                AmmoInventory.Instance.AddCartridge(cartridge, count);
+            }
         }
     }
 }

--- a/BoneLib/BoneLib/Preferences.cs
+++ b/BoneLib/BoneLib/Preferences.cs
@@ -1,4 +1,6 @@
-﻿using MelonLoader;
+﻿using Il2CppSLZ.Marrow;
+using Il2CppSLZ.Marrow.Data;
+using MelonLoader;
 
 namespace BoneLib
 {
@@ -15,6 +17,16 @@ namespace BoneLib
             skipIntro = new ModPref<bool>(category, "SkipIntro", false);
             loggingMode = new ModPref<LoggingMode>(category, "LoggingMode", LoggingMode.NORMAL);
             infiniteAmmo = new ModPref<bool>(category, "InfiniteAmmo", false);
+            if (infiniteAmmo.entry.Value)
+            {
+                AmmoInventory ammoInventory = AmmoInventory.Instance;
+                AmmoGroup[] ammoGroups = {ammoInventory.lightAmmoGroup, ammoInventory.mediumAmmoGroup, ammoInventory.heavyAmmoGroup};
+                string[] ammoCartridges = {"light","medium", "heavy"};
+                for (int i = 0; i < 3; i++)
+                {
+                    if (ammoInventory.GetCartridgeCount(ammoCartridges[i]) < 1) ammoInventory.AddCartridge(ammoGroups[i], short.MaxValue);
+                }
+            }
             Save();
             ModConsole.Msg("Finished preferences setup", LoggingMode.DEBUG);
         }

--- a/BoneLib/BoneLib/Preferences.cs
+++ b/BoneLib/BoneLib/Preferences.cs
@@ -17,18 +17,38 @@ namespace BoneLib
             skipIntro = new ModPref<bool>(category, "SkipIntro", false);
             loggingMode = new ModPref<LoggingMode>(category, "LoggingMode", LoggingMode.NORMAL);
             infiniteAmmo = new ModPref<bool>(category, "InfiniteAmmo", false);
+            infiniteAmmo.entry.OnEntryValueChanged.Subscribe((_, value) =>
+            {
+                // Gives Ammo once the preference is toggled on
+                if (value)
+                {
+                    GiveAmmo();
+                }
+            });
             if (infiniteAmmo.entry.Value)
             {
-                AmmoInventory ammoInventory = AmmoInventory.Instance;
-                AmmoGroup[] ammoGroups = {ammoInventory.lightAmmoGroup, ammoInventory.mediumAmmoGroup, ammoInventory.heavyAmmoGroup};
-                string[] ammoCartridges = {"light","medium", "heavy"};
-                for (int i = 0; i < 3; i++)
-                {
-                    if (ammoInventory.GetCartridgeCount(ammoCartridges[i]) < 1) ammoInventory.AddCartridge(ammoGroups[i], short.MaxValue);
-                }
+                GiveAmmo();
             }
             Save();
             ModConsole.Msg("Finished preferences setup", LoggingMode.DEBUG);
+        }
+
+        // Added from hahoos comment
+        internal static void GiveAmmo()
+        {
+            if (infiniteAmmo.entry.Value)
+            {
+                // Gets the ammo inventory
+                AmmoInventory ammoInventory = AmmoInventory.Instance;
+                // Creates an array of groups and carts.
+                AmmoGroup[] ammoGroups = { ammoInventory.lightAmmoGroup, ammoInventory.mediumAmmoGroup, ammoInventory.heavyAmmoGroup };
+                string[] ammoCartridges = { "light", "medium", "heavy" };
+                for (int i = 0; i < 3; i++)
+                {
+                    // Adds cart. if there is no ammo
+                    if (ammoInventory.GetCartridgeCount(ammoCartridges[i]) < 1) ammoInventory.AddCartridge(ammoGroups[i], short.MaxValue);
+                }
+            }
         }
 
         public static void Save()

--- a/BoneLib/BoneLib/Preferences.cs
+++ b/BoneLib/BoneLib/Preferences.cs
@@ -8,14 +8,20 @@ namespace BoneLib
 
         public static ModPref<LoggingMode> loggingMode;
         public static ModPref<bool> skipIntro;
+        public static ModPref<bool> infiniteAmmo;
 
         public static void Setup()
         {
             skipIntro = new ModPref<bool>(category, "SkipIntro", false);
             loggingMode = new ModPref<LoggingMode>(category, "LoggingMode", LoggingMode.NORMAL);
-
-            category.SaveToFile(false);
+            infiniteAmmo = new ModPref<bool>(category, "InfiniteAmmo", false);
+            Save();
             ModConsole.Msg("Finished preferences setup", LoggingMode.DEBUG);
+        }
+
+        public static void Save()
+        {
+            category.SaveToFile(false);
         }
     }
 }


### PR DESCRIPTION
- Added Infinite Ammo Toggle in Ammo Settings
- Added `Preferences.Save` Function
- Added infiniteAmmo `ModPref` in `Preferences` class

Thought it would be a good idea to have infinite ammo in BoneLib by default instead of requiring a separate infinite ammo code mod, especially because of the existence of ammo settings in BoneLib