### PR TITLE
Fix BoneMenu breaking on Quest when a page has too many of the same type of element

### DIFF
--- a/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
@@ -86,7 +86,7 @@ namespace BoneLib.BoneMenu.UI
         public void OnReturn(GUIPoolee poolee)
         {
             _inactiveObjects.Add(poolee.gameObject);
-            _activeObjects.Remove(poolee.gameObject);
+            _activeObjects.RemoveIl2Cpp(poolee.gameObject);
             poolee.gameObject.SetActive(false);
             poolee.transform.SetParent(transform);
         }

--- a/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
@@ -64,6 +64,11 @@ namespace BoneLib.BoneMenu.UI
             {
                 GameObject activeObject = _activeObjects[i];
 
+                if (activeObject == null)
+                {
+                    _activeObjects.RemoveAt(i--);
+                    continue;
+                }
                 if (!activeObject.TryGetComponent(out GUIPoolee poolee))
                 {
                     continue;
@@ -110,6 +115,11 @@ namespace BoneLib.BoneMenu.UI
 
             for (int i = 0; i < list.Count; i++)
             {
+                if (list[i] == null)
+                {
+                    list.RemoveAt(i--);
+                    continue;
+                }
                 if (!list[i].activeInHierarchy)
                 {
                     found = list[i];

--- a/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
+++ b/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs
@@ -43,12 +43,6 @@ namespace BoneLib.BoneMenu.UI
         {
             GameObject clone = GetFirst(_inactiveObjects);
 
-            if (_inactiveObjects.Count == 0)
-            {
-                Grow(_size);
-                return Spawn(parent);
-            }
-
             _activeObjects.Add(clone);
             _inactiveObjects.Remove(clone);
             clone.transform.SetParent(parent);
@@ -112,8 +106,9 @@ namespace BoneLib.BoneMenu.UI
         private GameObject GetFirst(List<GameObject> list)
         {
             GameObject found = null;
+            int i;
 
-            for (int i = 0; i < list.Count; i++)
+            for (i = 0; i < list.Count; i++)
             {
                 if (list[i] == null)
                 {
@@ -127,7 +122,11 @@ namespace BoneLib.BoneMenu.UI
                 }
             }
 
-            return found;
+            if (found != null)
+                return found;
+
+            Grow(_size);
+            return list[i];
         }
     }
 }

--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -161,7 +161,7 @@ namespace BoneLib
         /// </summary>
         public static bool ContainsIl2Cpp<T>(this ICollection<T> coll, T item) where T : Il2CppObjectBase
         {
-            if (MelonUtils.IsWindows)
+            if (MelonUtils.IsWindows || item == null)
                 return coll.Contains(item);
             foreach (var x in coll)
                 if (x.Pointer == item.Pointer)
@@ -180,7 +180,7 @@ namespace BoneLib
         /// </returns>
         public static bool RemoveIl2Cpp<T>(this ICollection<T> coll, T item) where T : Il2CppObjectBase
         {
-            if (MelonUtils.IsWindows)
+            if (MelonUtils.IsWindows || item == null)
             {
                 return coll.Remove(item);
             }
@@ -222,7 +222,7 @@ namespace BoneLib
         /// </returns>
         public static int IndexOfIl2Cpp<T>(this IList<T> list, T item) where T : Il2CppObjectBase
         {
-            if (MelonUtils.IsWindows)
+            if (MelonUtils.IsWindows || item == null)
                 return list.IndexOf(item);
             for (int i = 0; i < list.Count; i++)
                 if (list[i].Pointer == item.Pointer)

--- a/BoneLib/BoneLib/HelperMethods.cs
+++ b/BoneLib/BoneLib/HelperMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using MelonLoader;
 using System.Text.RegularExpressions;
+using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppSLZ.Marrow.Data;
 using Il2CppSLZ.Marrow.Pool;
 using Il2CppSLZ.Marrow.SceneStreaming;
@@ -150,6 +151,83 @@ namespace BoneLib
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Checks if the collection contains a specific Il2Cpp object.
+        /// On Android it compares the <see cref="Il2CppObjectBase.Pointer"/> of each object
+        /// instead of the objects themselves.
+        /// On Windows it behaves identically to <see cref="ICollection{T}.Contains(T)"/>.
+        /// </summary>
+        public static bool ContainsIl2Cpp<T>(this ICollection<T> coll, T item) where T : Il2CppObjectBase
+        {
+            if (MelonUtils.IsWindows)
+                return coll.Contains(item);
+            foreach (var x in coll)
+                if (x.Pointer == item.Pointer)
+                    return true;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the first occurrence of a specific Il2Cpp object from the collection.
+        /// On Android it compares the <see cref="Il2CppObjectBase.Pointer"/> of each object
+        /// instead of the objects themselves.
+        /// On Windows it behaves identically to <see cref="ICollection{T}.Remove(T)"/>.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="item"/> was removed; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool RemoveIl2Cpp<T>(this ICollection<T> coll, T item) where T : Il2CppObjectBase
+        {
+            if (MelonUtils.IsWindows)
+            {
+                return coll.Remove(item);
+            }
+            else if (coll is IList<T> list)
+            {
+                for (int i = 0; i < list.Count; i++)
+                    if (list[i].Pointer == item.Pointer)
+                    {
+                        list.RemoveAt(i);
+                        return true;
+                    }
+                return false;
+            }
+            else
+            {
+                T match = null;
+                bool found = false;
+                foreach (var x in coll)
+                    if (x.Pointer == item.Pointer)
+                    {
+                        match = x;
+                        found = true;
+                        break;
+                    }
+                if (found)
+                    return coll.Remove(match);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of a specific Il2Cpp object in the list.
+        /// On Android it compares the <see cref="Il2CppObjectBase.Pointer"/> of each object
+        /// instead of the objects themselves.
+        /// On Windows it behaves identically to <see cref="IList{T}.IndexOf(T)"/>.
+        /// </summary>
+        /// <returns>
+        /// The index of <paramref name="item"/> if found in the list; otherwise, -1.
+        /// </returns>
+        public static int IndexOfIl2Cpp<T>(this IList<T> list, T item) where T : Il2CppObjectBase
+        {
+            if (MelonUtils.IsWindows)
+                return list.IndexOf(item);
+            for (int i = 0; i < list.Count; i++)
+                if (list[i].Pointer == item.Pointer)
+                    return i;
+            return -1;
         }
     }
 }


### PR DESCRIPTION
* Fixes _GUIPool.OnReturn_ never removing anything from its active object list on Quest.
* Fixes _GUIPool.Spawn_ failing to grow the pool when every GameObject in the pool is active.
* Makes _GUIPool.Spawn_ and _GUIPool.ReturnAll_ remove any null references in the pool. 
* Adds helper methods that can be used as replacements for _ICollection.Contains_, _ICollection.Remove_, and _IList.IndexOf_ except they work correctly on Quest.

This fixes issues #70 and #107. You can now have as many elements on a page as you want.

The source of this bug is a LemonLoader-specific issue where two different references to the same Il2Cpp object are sometimes not considered equal to each other. This affects anything that checks for equality including the "==" operator, searching in collections, dictionaries with Il2Cpp objects as keys, etc. I don't really know enough about MelonLoader to say why this happens or why it only happens on the Quest version. The workaround is to always compare the _Pointer_ property of Il2Cpp objects instead of the objects themselves. This is what the new helper methods do.

The reason this breaks the menu is as follows:

1. Whenever the player moves to a different page, _ReturnAll_ is called, which then calls _OnReturn_ for every active GUI element.
2. __activeObjects.Remove_ always fails on Quest because __activeObjects_ contains a different wrapper object than what _poolee.gameObject_ returns, even though they both point to the same underlying Il2Cpp object.
https://github.com/yowchap/BoneLib/blob/68feb91591a98ad440a9972a2dc286e74e208ea1/BoneLib/BoneLib/BoneMenu/UI/GUIPool.cs#L86-L92
3. Every subsequent time _ReturnAll_ is called, the same list of objects is appended to __inactiveObjects_ over and over again.
4. _Spawn_ calls _GetFirst_ which tries to get the first object from the __inactiveObjects_ list that isn't _activeInHierarchy_. It returns null if it doesn't find one. After a certain sequence of calls to _Spawn_ and _ReturnAll_ the list will only contain active objects because they are all duplicate references to objects that were already spawned.
5. _Spawn_ does not check if _GetFirst_ returned null and then causes a _NullReferenceException_.